### PR TITLE
moar fixxsz

### DIFF
--- a/lib/Mojo/Pg/Migrations.pm
+++ b/lib/Mojo/Pg/Migrations.pm
@@ -33,7 +33,7 @@ sub from_string {
   return $self;
 }
 
-sub latest { (sort keys %{shift->{migrations}{up}})[-1] || 0 }
+sub latest { (sort { $a <=> $b } keys %{shift->{migrations}{up}})[-1] || 0 }
 
 sub migrate {
   my ($self, $target) = @_;

--- a/lib/Mojo/Pg/Migrations.pm
+++ b/lib/Mojo/Pg/Migrations.pm
@@ -55,13 +55,14 @@ sub migrate {
   # Up
   my $sql;
   if ($active < $target) {
-    my @up = grep { $_ <= $target && $_ > $active } sort keys %$up;
+
+    my @up = grep { $_ <= $target && $_ > $active } sort { $a <=> $b } keys %$up;
     $sql = join '', @$up{@up};
   }
 
   # Down
   else {
-    my @down = grep { $_ > $target && $_ <= $active } reverse sort keys %$down;
+    my @down = grep { $_ > $target && $_ <= $active } reverse sort { $a <=> $b } keys %$down;
     $sql = join '', @$down{@down};
   }
 

--- a/t/migrations.t
+++ b/t/migrations.t
@@ -72,20 +72,51 @@ drop table if exists migration_test_two;
 insert into migration_test_two values ('works too');
 -- 4 down (not up)
 delete from migration_test_two where bar = 'works too';
+
+-- 5 up (not down)
+insert into migration_test_two values ('works too');
+-- 5 down (not up)
+delete from migration_test_two where bar = 'works too';
+
+-- 6 up (not down)
+insert into migration_test_two values ('works too');
+-- 6 down (not up)
+delete from migration_test_two where bar = 'works too';
+
+-- 7 up (not down)
+insert into migration_test_two values ('works too');
+-- 7 down (not up)
+delete from migration_test_two where bar = 'works too';
+
+-- 8 up (not down)
+insert into migration_test_two values ('works too');
+-- 8 down (not up)
+delete from migration_test_two where bar = 'works too';
+
+-- 11 up (not down)
+insert into migration_test_two values ('works too');
+-- 11 down (not up)
+delete from migration_test_two where bar = 'works too';
+
+-- 12 up (not down)
+insert into migration_test_two values ('works too');
+-- 12 down (not up)
+delete from migration_test_two where bar = 'works too';
+
 EOF
-is $pg->migrations->latest, 4, 'latest version is 4';
+is $pg->migrations->latest, 12, 'latest version is 12';
 is $pg->migrations->active, 0, 'active version is 0';
-is $pg->migrations->migrate->active, 4, 'active version is 4';
+is $pg->migrations->migrate->active, 12, 'active version is 12';
 is_deeply $pg->db->query('select * from migration_test_one')->hash,
   {foo => 'works ♥'}, 'right structure';
-is $pg->migrations->migrate->active, 4, 'active version is 4';
+is $pg->migrations->migrate->active, 12, 'active version is 12';
 is $pg->migrations->migrate(1)->active, 1, 'active version is 1';
 is $pg->db->query('select * from migration_test_one')->hash, undef,
   'no result';
 is $pg->migrations->migrate(3)->active, 3, 'active version is 3';
 is $pg->db->query('select * from migration_test_two')->hash, undef,
   'no result';
-is $pg->migrations->migrate->active, 4, 'active version is 4';
+is $pg->migrations->migrate->active, 12, 'active version is 12';
 is_deeply $pg->db->query('select * from migration_test_two')->hash,
   {bar => 'works too'}, 'right structure';
 is $pg->migrations->migrate(0)->active, 0, 'active version is 0';
@@ -101,7 +132,7 @@ like $@, qr/does_not_exist/, 'right error';
 is $pg2->migrations->migrate(3)->active, 3, 'active version is 3';
 is $pg2->migrations->migrate(2)->active, 2, 'active version is 3';
 is $pg->migrations->active, 0, 'active version is still 0';
-is $pg->migrations->migrate->active, 4, 'active version is 4';
+is $pg->migrations->migrate->active, 12, 'active version is 12';
 is_deeply $pg2->db->query('select * from migration_test_three')
   ->hashes->to_array, [{baz => 'just'}, {baz => 'works ♥'}],
   'right structure';

--- a/t/migrations.t
+++ b/t/migrations.t
@@ -40,6 +40,7 @@ is $pg->migrations->from_data->latest, 0, 'latest version is 0';
 is $pg->migrations->from_data(__PACKAGE__)->latest, 0, 'latest version is 0';
 is $pg->migrations->name('test1')->from_data->latest, 7, 'latest version is 7';
 is $pg->migrations->name('test2')->from_data->latest, 2, 'latest version is 2';
+is $pg->migrations->name('test3')->from_data->latest, 12, 'latest version is 12';
 is $pg->migrations->name('migrations')->from_data(__PACKAGE__, 'test1')
   ->latest, 7, 'latest version is 7';
 is $pg->migrations->name('test2')->from_data(__PACKAGE__)->latest, 2,
@@ -121,3 +122,42 @@ create table migration_test_four (test int));
 @@ test2
 -- 2 up
 create table migration_test_five (test int);
+
+@@ test3
+-- 1 up
+CREATE TABLE "MyTable" (
+    col1 text
+);
+
+-- 2 up
+ALTER TABLE "MyTable" ADD COLUMN col2 text;
+
+-- 3 up
+ALTER TABLE "MyTable" ADD COLUMN col3 text;
+
+-- 4 up
+ALTER TABLE "MyTable" ADD COLUMN col4 text;
+
+-- 5 up
+ALTER TABLE "MyTable" ADD COLUMN col5 text;
+
+-- 6 up
+ALTER TABLE "MyTable" ADD COLUMN col6 text;
+
+-- 7 up
+ALTER TABLE "MyTable" ADD COLUMN col7 text;
+
+-- 8 up
+ALTER TABLE "MyTable" ADD COLUMN col8 text;
+
+-- 9 up
+ALTER TABLE "MyTable" ADD COLUMN col9 text;
+
+-- 10 up
+ALTER TABLE "MyTable" ADD COLUMN col10 text;
+
+-- 11 up
+ALTER TABLE "MyTable" ADD COLUMN col11 text;
+
+-- 12 up
+ALTER TABLE "MyTable" ADD COLUMN col12 text;


### PR DESCRIPTION
in Mojo::Pg::Migrations::migrate there are 2 other potential sort errors, they are:
my @up = grep { $_ <= $target && $_ > $active } sort { $a <=> $b } keys %$up

my @down = grep { $_ > $target && $_ <= $active } reverse sort { $a <=> $b } keys %$down

my suggestion is to add { $a <=> $b } as in example.

