### PR TITLE
Give users a lifeline on how objects and methods are related

### DIFF
--- a/lib/Mojo/Pg.pm
+++ b/lib/Mojo/Pg.pm
@@ -202,11 +202,13 @@ gracefully by holding on to them only for short amounts of time.
 
   app->start;
 
-In the example, we use the controller's C<pg> helper defined here to return
-the C<Mojo::Pg> object, and then get the underlying L<Mojo::Pg::Database>
-object, which we can use to call the L<Mojo::Pg::Database/query> method. That
-method returns a L<Mojo::Pg::Results> object and we use its
-L<Mojo::Pg::Results/hash> method to retrieve the first row as a hash reference.
+In the example, we create a C<pg> helper to store a C<Mojo::Pg> object.  The
+action for C<'/'> calls that helper and uses the returned object's
+L<Mojo::Pg/"db"> method to dequeue a L<Mojo::Pg::Database> object from the
+connection pool.  We then call the L<Mojo::Pg::Database/query> method on the
+database object. The query returns a L<Mojo::Pg::Results> object, whose
+L<Mojo::Pg::Results/hash> method we use to retrieve the first row as a hash
+reference.
 
 While all I/O operations are performed blocking, you can wait for long running
 queries asynchronously, allowing the L<Mojo::IOLoop> event loop to perform

--- a/lib/Mojo/Pg.pm
+++ b/lib/Mojo/Pg.pm
@@ -202,6 +202,12 @@ gracefully by holding on to them only for short amounts of time.
 
   app->start;
 
+In the example, we use the controller's C<pg> helper defined here to return
+the C<Mojo::Pg> object, and then get the underlying L<Mojo::Pg::Database>
+object, which we can use to call the L<Mojo::Pg::Database/query> method. That
+method returns a L<Mojo::Pg::Results> object and we use its
+L<Mojo::Pg::Results/hash> method to retrieve the first row as a hash reference.
+
 While all I/O operations are performed blocking, you can wait for long running
 queries asynchronously, allowing the L<Mojo::IOLoop> event loop to perform
 other tasks in the meantime. Since database connections usually have a very low


### PR DESCRIPTION
Without some initial guidance, it is a bit of a fishing expedition among the several documents to discover where each of the elements of a call like `$c->pg->db->query->hash` is actually defined.