### PR TITLE
Add expander functionality

### DIFF
--- a/lib/Mojo/Pg/Database.pm
+++ b/lib/Mojo/Pg/Database.pm
@@ -80,7 +80,8 @@ sub query {
   # Blocking
   unless ($cb) {
     $self->_notifications;
-    return Mojo::Pg::Results->new(sth => $sth);
+    return Mojo::Pg::Results->new(sth => $sth,
+      expanders => $self->pg->expanders);
   }
 
   # Non-blocking


### PR DESCRIPTION
Expanding expand functionality
==============================

The expand functionality as discussed in [a gist](https://gist.github.com/chy-causer/cd1a151db9b21c278a10f8a2f363868b) has been implemented and is submitted for your consideration. It allows custom expansion of postgresql column types, as well as changing
the default Mojo::JSON::from_json, to JSON::XS for example.

Performance
-----------

Benchmarking script can be found at https://gist.github.com/chy-causer/66b15f14b16b06d3d9da0e36cd36ca04

|Benchmark|Before|After|
|---------|------|-----|
|expand->hashes  |53/s | 52/s|
|expand->hash    |42/s | 41/s|
|hashes          |90/s |91/s |
|bool::json      |50/s | 51/s|
|Extra expander  | -   | 51/s|
|bool expander   | -   | 67/s|

These numbers can be verified using the linked script.

From these benchmarks, it's clear there's very little difference in performance using the new code. However, for the not uncommon use case of wanting booleans represented as objects, there is a 30% speed increase as well as a more pleasing syntax.

    # One possible method:
    $db->query("SELECT row_to_json(t) r from ( select is_bool from _table) t" )->expand->hash->{r};

    vs

    $db->query("SELECT is_bool from _table")->expand->hash;

Backwards compatibility
-----------------------

All existing tests passed without modification

Pluggability
------------

Functionality is documented and shows how to convert bigints and booleans.

Implementation: An expand mapper
-------------

The code makes use of an expand mapper (cached for performance), which maps columns to expand coderefs. The rationale for using this to achieve the desired functionality is two-fold:

1. Performance
2. It allows future expansion of expand
    $results->expand(column_name => sub { ... } )->hash;

I did not pursue the latter as it's not something I need, but the option is there.

Addendum
--------

As it's my first submission to the Mojo project, I am well aware there may be issues in it, in terms of coding style and general best practice. However, there are a few things I would like to bring up in advance:

### _expand_mapper mapping both hashes and arrays

The _expand_mapper caches its result for performance. However, it caches both hash and array mappings, whether they're used or not.

This is to match the documentation that once the first row is returned, then you cannot alter the expanders. Consider the following:

$pg->db->query('select * from _table')->expand->hash->expanders({})->array;

This scenario is tested.

### What types are available

It turns out the DBD::Pg hard codes the list of row types in its source code. This means that extensions like ip4r return a type of 'unknown' and DBD::Pg will need to be patched and recompiled
to deal with new types as they are introduced to your database.

Furthermore, I cannot seem to find a nicely formatted list of available types DBD::Pg returns from $sth->{pg_type}. The best I can do is the DBD::Pg types.c source code!
