### PR TITLE
Isolation level attribute in Mojo::Pg::Transaction

### DIFF
--- a/lib/Mojo/Pg/Database.pm
+++ b/lib/Mojo/Pg/Database.pm
@@ -23,8 +23,8 @@ sub DESTROY {
 }
 
 sub begin {
-  my $self = shift;
-  my $tx = Mojo::Pg::Transaction->new(db => $self);
+  my ($self, $level) = @_;
+  my $tx = Mojo::Pg::Transaction->new(db => $self, level => $level);
   weaken $tx->{db};
   return $tx;
 }
@@ -239,10 +239,12 @@ implements the following new ones.
 =head2 begin
 
   my $tx = $db->begin;
+  my $tx = $db->begin('serializable');
 
 Begin transaction and return L<Mojo::Pg::Transaction> object, which will
 automatically roll back the transaction unless
 L<Mojo::Pg::Transaction/"commit"> has been called before it is destroyed.
+You can also pass isolation level for transaction.
 
   # Insert rows in a transaction
   eval {

--- a/t/results.t
+++ b/t/results.t
@@ -151,6 +151,13 @@ eval {
 like $@, qr/does_not_exist/, 'right error';
 is_deeply $db->query('select * from results_test where name = ?', 'tx3')
   ->hashes->to_array, [], 'no results';
+{
+  my $tx = $db->begin('repeatable read');
+  is $db->query('table results_test')->rows, 4, 'right result';
+  $pg->db->query("insert into results_test (name) values ('tx4')");
+  is $db->query('table results_test')->rows, 4, 'right result';
+  $tx->commit;
+}
 
 # Long-lived results
 my $results1 = $db->query('select 1 as one');


### PR DESCRIPTION
### Summary
When you need to specify a custom transaction isolation level you have to write additional code. Like this:

```perl
my $tx = $db->begin;
$db->dbh->do('set transaction isolation level repeatable read');
```
Useful when there is a helper in ``Mojo::Pg::Database``:

```perl
my $tx = $db->begin('repeatable read');
```
Also in such cases, the query ``set transaction`` must be first in this transaction, so it is more logical to put this query in ``Mojo::Pg::Transaction``.
