### PR TITLE
Accept protocol as postgresql and postgres

### DIFF
--- a/lib/Mojo/Pg.pm
+++ b/lib/Mojo/Pg.pm
@@ -46,7 +46,7 @@ sub from_string {
   return $self unless $str;
   my $url = Mojo::URL->new($str);
   croak qq{Invalid PostgreSQL connection string "$str"}
-    unless $url->protocol eq 'postgresql';
+    unless $url->protocol =~ /^(?:postgresql|postgres)$/;
 
   # Connection information
   my $db = $url->path->parts->[0];

--- a/t/connection.t
+++ b/t/connection.t
@@ -21,8 +21,8 @@ $options = {AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 0,
   RaiseError => 1};
 is_deeply $pg->options, $options, 'right options';
 
-# Minimal connection string with service and option
-$pg = Mojo::Pg->new('postgresql://?service=foo&PrintError=1');
+# Minimal connection string with service and option, shorter protocol
+$pg = Mojo::Pg->new('postgres://?service=foo&PrintError=1');
 is $pg->dsn,      'dbi:Pg:service=foo', 'right data source';
 is $pg->username, '',                   'no username';
 is $pg->password, '',                   'no password';


### PR DESCRIPTION
### Summary

This PR allows Mojo::Pg to accept urls like `postgres://...` in addition to `postgresql://...`. It helps complying with the generic setting for PostgreSQL, as e.g. stated [here](https://www.postgresql.org/docs/9.3/static/libpq-connect.html#AEN39271).

This also helps reduce friction with automated systems that set urls in the former way, e.g. [the Dokku plugin for PostgreSQL](https://github.com/dokku/dokku-postgres).

### Motivation

This allows broader compliance to [PostgreSQL rules](https://www.postgresql.org/docs/9.3/static/libpq-connect.html#AEN39271) and it is also a nice-to-have to avoid need for some munging e.g. in a Mojolicious application when receiving the `DATABASE_URL` parameter, like this:

    (my $url = $ENV{DATABASE_URL}) =~ s{^postgres:}{postgresql:};

### References

PostgreSQL documentation [explicitly states that both URI scheme are good](https://www.postgresql.org/docs/9.3/static/libpq-connect.html#AEN39271):

> The URI scheme designator can be either `postgresql://` or `postgres://`.

I hit this "impedance mismatch" while writing an article on deploying Perl applications on [Dokku](http://dokku.viewdocs.io/dokku/), you can find the article's relevant section [here](http://blog.polettix.it/dokku-your-tiny-paas/#backing-services). This to say that there actually other softwares out there that decided to adopt *the other* way of expressing URLs.

### Implementation

I chose to use regexps for compactness, TIMTOWTDI of course e.g.:

    unless ($url->protocol eq 'postgresql')
        || ($url->protocol eq 'postgres');