### PR TITLE
warn about using connect_cached

### DIFF
--- a/lib/Mojo/Pg.pm
+++ b/lib/Mojo/Pg.pm
@@ -334,8 +334,10 @@ easily.
 
 Options for database handles, defaults to activating C<AutoCommit>,
 C<AutoInactiveDestroy> as well as C<RaiseError> and deactivating C<PrintError>.
+
 Note that C<AutoCommit> and C<RaiseError> are considered mandatory, so
-deactivating them would be very dangerous.
+deactivating them would be very dangerous.  Setting C<dbi_connect_method>
+to C<connect_cached> is also likely to cause confusion, so don't do that.
 
 =head2 password
 


### PR DESCRIPTION
### Summary
warn not to do { dbi_connect_method => connect_cached } in Mojo::Pg parameters

### Motivation
I believe this is otherwise a common thing to do in website/DBI situations, and thus someone copying in miscellaneous DBI parameters from their non-Mojo implementation without thinking about it could get hosed with difficult-to-find errors if they're expecting transaction/asynchronous stuff to work right.  

Current doc **is** clear that there's some kind of caching going on somewhere in Mojo::Pg but without looking at the code, there's no knowing whether the lack of mention is, say, because Mojo::Pg is able to accomodate either setting (when it's not).

### References
none
