### PR TITLE
Fixed reusing dbh when sth is still exists.

### DIFF
--- a/lib/Mojo/Pg/Database.pm
+++ b/lib/Mojo/Pg/Database.pm
@@ -151,7 +151,7 @@ sub _watch {
       my $result = do { local $dbh->{RaiseError} = 0; $dbh->pg_result };
       my $err = defined $result ? undef : $dbh->errstr;
 
-      $self->$cb($err, $self->results_class->new(sth => $sth));
+      $self->$cb($err, $self->results_class->new(sth => $sth, db => $self));
       $self->_unwatch unless $self->{waiting} || $self->is_listening;
     }
   )->watch($self->{handle}, 1, 0);

--- a/lib/Mojo/Pg/Results.pm
+++ b/lib/Mojo/Pg/Results.pm
@@ -5,7 +5,7 @@ use Mojo::Collection;
 use Mojo::JSON 'from_json';
 use Mojo::Util 'tablify';
 
-has 'sth';
+has [qw(sth db)];
 
 sub DESTROY {
   my $self = shift;


### PR DESCRIPTION
### Summary
Fix of referenced issue. We store db object to results object to prevent inconsistent behavior.

### Motivation
When we using async operations, and got db and results object - we can pass result object to subfunction. After that result object continues to exists, and db - not, so DESTROY on db called and dbh returns to queue.

### References
https://github.com/kraih/mojo-pg/issues/36
