### PR TITLE
change deprecated Mojo::Util::slurp with Mojo::File::slurp

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -29,6 +29,6 @@ WriteMakefile(
       x_IRC => 'irc://irc.perl.org/#mojo'
     },
   },
-  PREREQ_PM => {Mojolicious => '7.12', 'DBD::Pg' => 3.005001},
+  PREREQ_PM => {Mojolicious => '7.15', 'DBD::Pg' => 3.005001},
   test      => {TESTS       => 't/*.t t/*/*.t'}
 );

--- a/lib/Mojo/Pg/Migrations.pm
+++ b/lib/Mojo/Pg/Migrations.pm
@@ -2,8 +2,9 @@ package Mojo::Pg::Migrations;
 use Mojo::Base -base;
 
 use Carp 'croak';
+use Mojo::File 'path';
 use Mojo::Loader 'data_section';
-use Mojo::Util qw(decode slurp);
+use Mojo::Util 'decode';
 
 use constant DEBUG => $ENV{MOJO_MIGRATIONS_DEBUG} || 0;
 
@@ -18,7 +19,7 @@ sub from_data {
     data_section($class //= caller, $name // $self->name));
 }
 
-sub from_file { shift->from_string(decode 'UTF-8', slurp pop) }
+sub from_file { shift->from_string(decode 'UTF-8', path(pop)->slurp) }
 
 sub from_string {
   my ($self, $sql) = @_;


### PR DESCRIPTION
### Summary
With new `Mojolicious` v7.15 `Mojo::Pg::Migrations::from_file` started generate warnings `Mojo::Util::slurp is DEPRECATED in favor of Mojo::File::slurp`.

### Motivation
Fix warnings.

