### PR TITLE
Set name_sep for default SQL::Abstract to help disambiguate columns

### DIFF
--- a/lib/Mojo/Pg.pm
+++ b/lib/Mojo/Pg.pm
@@ -10,7 +10,7 @@ use Mojo::URL;
 use Scalar::Util 'weaken';
 use SQL::Abstract;
 
-has abstract => sub { SQL::Abstract->new(quote_char => '"') };
+has abstract => sub { SQL::Abstract->new(quote_char => '"', name_sep => '.') };
 has [qw(auto_migrate search_path)];
 has database_class  => 'Mojo::Pg::Database';
 has dsn             => 'dbi:Pg:';


### PR DESCRIPTION
When using SQL::Abstract with multiple tables, it is sometimes necessary to disambiguate columns:

    $pg->db->select(['foo', 'bar'], ['foo.id'], {'foo.id', => {-ident => 'bar.id'}});

If SQL::Abstract does not have a name_sep specified, it will attempt to quote the entire table-field name as `"foo.id"` and `"bar.id"` rather than `"foo"."id"` and `"bar"."id"`, producing an error such as:

    DBD::Pg::st execute failed: ERROR:  column "foo.id" does not exist
    LINE 1: SELECT "foo.id" FROM "foo", "bar" WHERE ( "foo.id" = "bar.id...
                   ^ at lib/Test.pm line 50.

The workaround is to create the Mojo::Pg instance with:

        $pg = Mojo::Pg
          ->new($db_uri)
          ->abstract(SQL::Abstract->new(quote_char => '"', name_sep => '.'))
          ;

However, since the name_sep and quote_char values are intrinsic to Postgres, it makes sense for these to be the setting on the default SQL::Abstract object.