### PR TITLE
stricter checking of migration target

### DIFF
--- a/lib/Mojo/Pg/Migrations.pm
+++ b/lib/Mojo/Pg/Migrations.pm
@@ -59,6 +59,8 @@ sub migrate {
   # Newer version
   croak "Active version $active is greater than the latest version $latest"
     if $active > $latest;
+  croak "Target version $target is greater than the latest version $latest"
+    if $target > $latest;
 
   # Up
   my $sql;


### PR DESCRIPTION
### Summary
It will disallow ->migrate($n) if $n is greater than the known levels.

### Motivation
Currently 'migrate' will disallow a change if $latest is greater than the known levels ($latest).  This change should mean the user doesn't get into that situation erroneously.

Slightly related, 'migrate' allows a change to levels for which there are no steps.  That makes sense if the $target is within the range of known steps.  (eg migrating 3-->2 even tho there's no 'down' step from 3 to 2)

(I suppose the biggest gain is for authors of other backends since it clarifies the semantics.)

### References
https://irclog.perlgeek.de/mojo/2017-06-25#i_14784815
