### PR TITLE
grab the last path part to get the "db name" instead of the first pat…

### DIFF
--- a/lib/Mojo/Pg.pm
+++ b/lib/Mojo/Pg.pm
@@ -38,7 +38,7 @@ sub from_string {
   croak qq{Invalid PostgreSQL connection string "$str"} unless $url->protocol =~ /^postgres(?:ql)?$/;
 
   # Connection information
-  my $db  = $url->path->parts->[0];
+  my $db  = $url->path->parts->[-1];
   my $dsn = defined $db ? "dbi:Pg:dbname=$db" : 'dbi:Pg:';
   if (my $host = $url->host)                  { $dsn .= ";host=$host" }
   if (my $port = $url->port)                  { $dsn .= ";port=$port" }

--- a/t/connection.t
+++ b/t/connection.t
@@ -92,4 +92,16 @@ subtest 'Invalid connection string' => sub {
   like $@, qr/Invalid PostgreSQL connection string/, 'right error';
 };
 
+subtest 'Connection string with a user, "file path" as hostname, port' => sub {
+  my $pg = Mojo::Pg->new("postgresql://user:@/var/run/postgresql:5432/db_name");
+  is $pg->dsn, "dbi:Pg:dbname=db_name", "db_name should be 'db_name' instead of 'var'";
+};
+
+subtest 'Connection string with a user, with pass, "file path" as hostname, port' => sub {
+  my $pass = "PASSWORD";
+  my $pg   = Mojo::Pg->new("postgresql://user:$pass@/var/run/postgresql:5432/db_name");
+  is $pg->dsn,      "dbi:Pg:dbname=db_name", "db_name should be 'db_name' instead of 'var'";
+  is $pg->password, $pass,                   "password parsed correctly";
+};
+
 done_testing();


### PR DESCRIPTION
…h part. this allows unix paths as the hostname. example: postgresql://user:@/var/run/postgresql:5432/MY_DB_NAME

### Summary
Allow "file paths" as hostname on the dsn.

Example: postgresql://user:@/var/run/postgresql:5432/db_name

Host should be: /var/run/postgresql
DB should be = "db_name"

However, since it grabs the first path part, it considers the db name = "var" as seen in the following test:

```
#   Failed test 'got the expected dsn result: dbi:Pg:dbname=db_name'
#   at /home/administrator/dev/mojo-pg/t/dsn.t line 47.
#          got: 'dbi:Pg:dbname=var'
#     expected: 'dbi:Pg:dbname=db_name'
# Looks like you failed 1 test of 7.
```



### Motivation
EXPLAIN WHY YOU BELIEVE THESE CHANGES ARE NECESSARY HERE

### References
LIST RELEVANT ISSUES, PULL REQUESTS AND FORUM DISCUSSIONS HERE
